### PR TITLE
Fix double release when scriptingProfile is set

### DIFF
--- a/MTTabController.m
+++ b/MTTabController.m
@@ -43,6 +43,8 @@
 - (void) MouseTerm_tabControllerDealloc
 {
     [[(TTTabController *)self profile] release];
+    Ivar sPivar = class_getInstanceVariable([self class], "_scriptingProfile");
+    object_setIvar(self, sPivar, nil);
     [self MouseTerm_tabControllerDealloc];
 }
 


### PR DESCRIPTION
When a setScriptingSomething function is called a TTemporaryProfile is created from the original TTProfile and assigned to the scriptingProfile ivar. This variable is freed during dealloc, but the profile is already release by our custom dealer so we just set it to nil
